### PR TITLE
CMake updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(minisat)
 # Configurable options:
 
 option(STATIC_BINARIES "Link binaries statically." ON)
+option(BUILD_STATIC_LIBS "Build static library." ON)
 option(USE_SORELEASE   "Use SORELEASE in shared library filename." ON)
 
 #--------------------------------------------------------------------------------------------------
@@ -51,11 +52,19 @@ set(MINISAT_LIB_SOURCES
     minisat/core/Solver.cc
     minisat/simp/SimpSolver.cc)
 
-add_library(minisat-lib-static STATIC ${MINISAT_LIB_SOURCES})
-add_library(minisat-lib-shared SHARED ${MINISAT_LIB_SOURCES})
+if (BUILD_STATIC_LIBS OR STATIC_BINARIES)
+	add_library(minisat-lib-static STATIC ${MINISAT_LIB_SOURCES})
+	target_link_libraries(minisat-lib-static ${ZLIB_LIBRARY})
+	set_target_properties(minisat-lib-static PROPERTIES OUTPUT_NAME "minisat")
+endif()
 
+add_library(minisat-lib-shared SHARED ${MINISAT_LIB_SOURCES})
 target_link_libraries(minisat-lib-shared ${ZLIB_LIBRARY})
-target_link_libraries(minisat-lib-static ${ZLIB_LIBRARY})
+set_target_properties(minisat-lib-shared
+  PROPERTIES
+    OUTPUT_NAME "minisat"
+    VERSION ${MINISAT_VERSION}
+    SOVERSION ${MINISAT_SOVERSION})
 
 add_executable(minisat_core minisat/core/Main.cc)
 add_executable(minisat_simp minisat/simp/Main.cc)
@@ -68,13 +77,6 @@ else()
   target_link_libraries(minisat_simp minisat-lib-shared)
 endif()
 
-set_target_properties(minisat-lib-static PROPERTIES OUTPUT_NAME "minisat")
-set_target_properties(minisat-lib-shared
-  PROPERTIES
-    OUTPUT_NAME "minisat" 
-    VERSION ${MINISAT_VERSION}
-    SOVERSION ${MINISAT_SOVERSION})
-
 set_target_properties(minisat_simp       PROPERTIES OUTPUT_NAME "minisat")
 
 #--------------------------------------------------------------------------------------------------
@@ -82,7 +84,12 @@ set_target_properties(minisat_simp       PROPERTIES OUTPUT_NAME "minisat")
 
 set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "Output directory for libraries")
 
-install(TARGETS minisat-lib-static minisat-lib-shared minisat_core minisat_simp 
+if (BUILD_STATIC_LIBS)
+	install(TARGETS minisat-lib-static
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+install(TARGETS minisat-lib-shared minisat_core minisat_simp
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,12 @@ set_target_properties(minisat_simp       PROPERTIES OUTPUT_NAME "minisat")
 #--------------------------------------------------------------------------------------------------
 # Installation targets:
 
+set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "Output directory for libraries")
+
 install(TARGETS minisat-lib-static minisat-lib-shared minisat_core minisat_simp 
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib)
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(DIRECTORY minisat/mtl minisat/utils minisat/core minisat/simp
         DESTINATION include/minisat


### PR DESCRIPTION
Allow for easier builds from rpm.

It's impossible to package stp without c65ff70 in multiarchitecture distros -- the ones that provide 32bit and 64bit versions of packages. Like Fedora, Ubuntu, or openSUSE do. 64bit libraries must be placed to `/usr/lib64` there. `/usr/lib` is only for 32bit libraries.

Building static libs is superfluous in distros and only wastes resources. The first thing after compilation we do is `rm -f *.a`. Hence 295a4a7.