### PR TITLE
utils/System.*: use fpu_control only on glibc

### DIFF
--- a/minisat/utils/System.cc
+++ b/minisat/utils/System.cc
@@ -97,7 +97,7 @@ double Minisat::memUsedPeak(bool /*strictlyPeak*/) { return 0; }
 
 void Minisat::setX86FPUPrecision()
 {
-#if defined(__linux__) && defined(_FPU_EXTENDED) && defined(_FPU_DOUBLE) && defined(_FPU_GETCW)
+#if defined(__GLIBC__) && defined(_FPU_EXTENDED) && defined(_FPU_DOUBLE) && defined(_FPU_GETCW)
     // Only correct FPU precision on Linux architectures that needs and supports it:
     fpu_control_t oldcw, newcw;
     _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);

--- a/minisat/utils/System.h
+++ b/minisat/utils/System.h
@@ -21,7 +21,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_System_h
 #define Minisat_System_h
 
-#if defined(__linux__)
+#if defined(__GLIBC__)
 #include <fpu_control.h>
 #endif
 


### PR DESCRIPTION
Bug: https://github.com/vprover/vampire/pull/432
Signed-off-by: Maciej Barć <xgqt@gentoo.org>